### PR TITLE
Update package.json to reference GoDaddy repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/asherah.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jgowdy/asherah-cobhan.git"
+    "url": "https://github.com/godaddy/asherah-node.git"
   },
   "scripts": {
     "build": "npx tsc",


### PR DESCRIPTION
Hey folks I noticed the [npm page](https://www.npmjs.com/package/asherah) for this package references the archived repo under [`jgowdy/asherah-cobhan`](https://github.com/jgowdy/asherah-cobhan/tree/main/node/asherah).

I updated the link here, so the reference should be correct now. I believe NPM infers the info from the `package.json`.