### PR TITLE
Integration test updates

### DIFF
--- a/integration/node/features/support/decrypt.js
+++ b/integration/node/features/support/decrypt.js
@@ -10,11 +10,12 @@ const fileDirectory = "/tmp/";
 var encryptedPayload;
 var decryptedPayload;
 
+var adoDatabaseHost = process.env.TEST_DB_HOSTNAME;
 var adoDatabaseName = process.env.TEST_DB_NAME;
 var adoUsername = process.env.TEST_DB_USER;
 var adoPassword = process.env.TEST_DB_PASSWORD;
 var adoPort = process.env.TEST_DB_PORT;
-var adoConnectionString = adoUsername+":"+adoPassword+"@tcp(localhost:"+adoPort+")/"+adoDatabaseName+"?tls=false"
+var adoConnectionString = adoUsername+":"+adoPassword+"@tcp("+adoDatabaseHost+":"+adoPort+")/"+adoDatabaseName+"?tls=false";
 
 Given('I have encrypted_data from {string}', async function (string) {
     var payload = fs.readFileSync(fileDirectory + string, 'utf8');

--- a/integration/node/features/support/encrypt.js
+++ b/integration/node/features/support/encrypt.js
@@ -6,9 +6,8 @@ const { Given, When, Then } = require('@cucumber/cucumber')
 const assert = require('assert');
 const asherah = require("asherah");
 const fs = require("fs");
-const os = require("os");
 
-const fileDirectory = os.tmpdir() + "/";
+const fileDirectory = "/tmp/";
 const fileName = "node_encrypted";
 
 let payloadString;

--- a/scripts/local-integration-test.sh
+++ b/scripts/local-integration-test.sh
@@ -31,6 +31,7 @@ trap cleanup INT
 trap cleanup EXIT
 
 export MYSQL_HOSTNAME=mysql
+export TEST_DB_HOSTNAME=localhost
 export TEST_DB_NAME=testdb
 export TEST_DB_USER=root
 export TEST_DB_PASSWORD=Password123
@@ -55,12 +56,12 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Waiting for MySQL to come up"
-while ! mysqladmin ping --protocol=tcp -u "${TEST_DB_USER}" -p"${TEST_DB_PASSWORD}" --silent 2>/dev/null; do
+while ! $CONTAINER_CMD exec $MYSQL_CONTAINER_ID mysqladmin ping --protocol=tcp -u "${TEST_DB_USER}" -p"${TEST_DB_PASSWORD}" --silent 2>/dev/null; do
     sleep 1
 done
 
 echo "Create encryption_key table"
-mysql --protocol=tcp -P "${TEST_DB_PORT}" -u "${TEST_DB_USER}" -p"${TEST_DB_PASSWORD}" -e "CREATE TABLE ${TEST_DB_NAME}.encryption_key (
+$CONTAINER_CMD exec $MYSQL_CONTAINER_ID mysql --protocol=tcp -P "${TEST_DB_PORT}" -u "${TEST_DB_USER}" -p"${TEST_DB_PASSWORD}" -e "CREATE TABLE ${TEST_DB_NAME}.encryption_key (
           id             VARCHAR(255) NOT NULL,
           created        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
           key_record     TEXT         NOT NULL,


### PR DESCRIPTION
### Modifications

`scripts/local-integration-test.sh`:
- Add missing export, `TEST_DB_HOSTNAME`. This variable is required by the cucumber feature implementation scripts.
- Execute `mysqladmin` commands inside the running mysql container, eliminating the client dependency.

`integration/node/features/support/encrypt.js`:
- Use the same working directory as `decrypt.js` (and the integration Asherah integration test suite). 

`integration/node/features/support/decrypt.js`:
- Use `TEST_DB_HOSTNAME` env variable for consistency (replaced hardcoded "localhost").