### PR TITLE
Integration test updates

### DIFF
--- a/integration/node/features/support/decrypt.js
+++ b/integration/node/features/support/decrypt.js
@@ -10,11 +10,12 @@ const fileDirectory = "/tmp/";
 var encryptedPayload;
 var decryptedPayload;
 
+var adoDatabaseHost = process.env.TEST_DB_HOSTNAME;
 var adoDatabaseName = process.env.TEST_DB_NAME;
 var adoUsername = process.env.TEST_DB_USER;
 var adoPassword = process.env.TEST_DB_PASSWORD;
 var adoPort = process.env.TEST_DB_PORT;
-var adoConnectionString = adoUsername+":"+adoPassword+"@tcp(localhost:"+adoPort+")/"+adoDatabaseName+"?tls=false"
+var adoConnectionString = adoUsername+":"+adoPassword+"@tcp("+adoDatabaseHost+":"+adoPort+")/"+adoDatabaseName+"?tls=false";
 
 Given('I have encrypted_data from {string}', async function (string) {
     var payload = fs.readFileSync(fileDirectory + string, 'utf8');

--- a/integration/node/features/support/encrypt.js
+++ b/integration/node/features/support/encrypt.js
@@ -6,9 +6,8 @@ const { Given, When, Then } = require('@cucumber/cucumber')
 const assert = require('assert');
 const asherah = require("asherah");
 const fs = require("fs");
-const os = require("os");
 
-const fileDirectory = os.tmpdir() + "/";
+const fileDirectory = "/tmp/";
 const fileName = "node_encrypted";
 
 let payloadString;

--- a/integration/node/package-lock.json
+++ b/integration/node/package-lock.json
@@ -10,9 +10,35 @@
       "license": "MIT",
       "dependencies": {
         "@cucumber/cucumber": "^7.3.2",
-        "asherah": "*",
+        "asherah": "file:../..",
         "assert": "^2.1.0",
         "fs": "^0.0.1-security"
+      }
+    },
+    "../..": {
+      "name": "asherah",
+      "version": "0.0.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.0.0"
+      },
+      "devDependencies": {
+        "@cucumber/cucumber": "^10.6.0",
+        "@types/chai": "^4.3.0",
+        "@types/mocha": "^9.1.1",
+        "@types/node": "^17.0.22",
+        "@typescript-eslint/eslint-plugin": "^5.16.0",
+        "@typescript-eslint/parser": "^5.16.0",
+        "chai": "^4.3.6",
+        "eslint": "^8.11.0",
+        "microtime": "^3.0.0",
+        "mocha": "^9.2.2",
+        "node-api-headers": "^1.1.0",
+        "nyc": "^15.1.0",
+        "ts-mocha": "^9.0.2",
+        "typescript": "^4.6.2",
+        "winston": "^3.11.0"
       }
     },
     "node_modules/@cucumber/create-meta": {
@@ -157,12 +183,8 @@
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "node_modules/asherah": {
-      "version": "1.0.44",
-      "resolved": "https://registry.npmjs.org/asherah/-/asherah-1.0.44.tgz",
-      "integrity": "sha512-Hv9Tom5A11eeSzagAIB+muFA5xnnolAyRGQ4yVQVSH6IlPYl7rfdLr4na58fqOI3uX5/VV2b3imkxiaJAcvI7g==",
-      "dependencies": {
-        "cobhan": "^1.0.27"
-      }
+      "resolved": "../..",
+      "link": true
     },
     "node_modules/assert": {
       "version": "2.1.0",
@@ -270,15 +292,6 @@
         "colors": "1.4.0"
       }
     },
-    "node_modules/cobhan": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/cobhan/-/cobhan-1.0.30.tgz",
-      "integrity": "sha512-Y5urOHpz3vUO1b91Ob0UPAne9PsXgVcIHmvJs+9Y8ouU/EFN5Vf2P3Y4R6Yq1ZHUFQPnl3W6JVyk+SliVSRSUQ==",
-      "dependencies": {
-        "ffi-napi": "^4.0.3",
-        "fs": "^0.0.1-security"
-      }
-    },
     "node_modules/colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -317,22 +330,6 @@
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/define-data-property": {
@@ -464,23 +461,6 @@
         "node >=0.6.0"
       ]
     },
-    "node_modules/ffi-napi": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
-      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-uv-event-loop-napi-h": "^1.0.5",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1",
-        "ref-napi": "^2.0.1 || ^3.0.2",
-        "ref-struct-di": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -530,19 +510,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-symbol-from-current-process-h": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-    },
-    "node_modules/get-uv-event-loop-napi-h": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-      "dependencies": {
-        "get-symbol-from-current-process-h": "^1.0.1"
       }
     },
     "node_modules/glob": {
@@ -791,11 +758,6 @@
         "node": "*"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -818,21 +780,6 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/object-assign": {
@@ -921,37 +868,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ref-napi": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
-      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-symbol-from-current-process-h": "^1.0.2",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/ref-struct-di": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
-      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
-      "dependencies": {
-        "debug": "^3.1.0"
-      }
-    },
-    "node_modules/ref-struct-di/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/reflect-metadata": {
@@ -1380,11 +1296,24 @@
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "asherah": {
-      "version": "1.0.44",
-      "resolved": "https://registry.npmjs.org/asherah/-/asherah-1.0.44.tgz",
-      "integrity": "sha512-Hv9Tom5A11eeSzagAIB+muFA5xnnolAyRGQ4yVQVSH6IlPYl7rfdLr4na58fqOI3uX5/VV2b3imkxiaJAcvI7g==",
+      "version": "file:../..",
       "requires": {
-        "cobhan": "^1.0.27"
+        "@cucumber/cucumber": "^10.6.0",
+        "@types/chai": "^4.3.0",
+        "@types/mocha": "^9.1.1",
+        "@types/node": "^17.0.22",
+        "@typescript-eslint/eslint-plugin": "^5.16.0",
+        "@typescript-eslint/parser": "^5.16.0",
+        "chai": "^4.3.6",
+        "eslint": "^8.11.0",
+        "microtime": "^3.0.0",
+        "mocha": "^9.2.2",
+        "node-addon-api": "^7.0.0",
+        "node-api-headers": "^1.1.0",
+        "nyc": "^15.1.0",
+        "ts-mocha": "^9.0.2",
+        "typescript": "^4.6.2",
+        "winston": "^3.11.0"
       }
     },
     "assert": {
@@ -1476,15 +1405,6 @@
         "string-width": "^4.2.0"
       }
     },
-    "cobhan": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/cobhan/-/cobhan-1.0.30.tgz",
-      "integrity": "sha512-Y5urOHpz3vUO1b91Ob0UPAne9PsXgVcIHmvJs+9Y8ouU/EFN5Vf2P3Y4R6Yq1ZHUFQPnl3W6JVyk+SliVSRSUQ==",
-      "requires": {
-        "ffi-napi": "^4.0.3",
-        "fs": "^0.0.1-security"
-      }
-    },
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -1517,14 +1437,6 @@
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
-      }
-    },
-    "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "requires": {
-        "ms": "2.1.2"
       }
     },
     "define-data-property": {
@@ -1633,19 +1545,6 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
       "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="
     },
-    "ffi-napi": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
-      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
-      "requires": {
-        "debug": "^4.1.1",
-        "get-uv-event-loop-napi-h": "^1.0.5",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1",
-        "ref-napi": "^2.0.1 || ^3.0.2",
-        "ref-struct-di": "^1.1.0"
-      }
-    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -1686,19 +1585,6 @@
         "has": "^1.0.3",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
-      }
-    },
-    "get-symbol-from-current-process-h": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-    },
-    "get-uv-event-loop-napi-h": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-      "requires": {
-        "get-symbol-from-current-process-h": "^1.0.1"
       }
     },
     "glob": {
@@ -1866,11 +1752,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -1894,16 +1775,6 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
-    },
-    "node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-    },
-    "node-gyp-build": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1965,35 +1836,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
-    },
-    "ref-napi": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
-      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
-      "requires": {
-        "debug": "^4.1.1",
-        "get-symbol-from-current-process-h": "^1.0.2",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1"
-      }
-    },
-    "ref-struct-di": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
-      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
-      "requires": {
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
     },
     "reflect-metadata": {
       "version": "0.1.13",

--- a/integration/node/package.json
+++ b/integration/node/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@cucumber/cucumber": "^7.3.2",
-    "asherah": "*",
+    "asherah": "file:../..",
     "assert": "^2.1.0",
     "fs": "^0.0.1-security"
   }

--- a/scripts/local-integration-test.sh
+++ b/scripts/local-integration-test.sh
@@ -31,6 +31,7 @@ trap cleanup INT
 trap cleanup EXIT
 
 export MYSQL_HOSTNAME=mysql
+export TEST_DB_HOSTNAME=localhost
 export TEST_DB_NAME=testdb
 export TEST_DB_USER=root
 export TEST_DB_PASSWORD=Password123
@@ -55,12 +56,12 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Waiting for MySQL to come up"
-while ! mysqladmin ping --protocol=tcp -u "${TEST_DB_USER}" -p"${TEST_DB_PASSWORD}" --silent 2>/dev/null; do
+while ! $CONTAINER_CMD exec $MYSQL_CONTAINER_ID mysqladmin ping --protocol=tcp -u "${TEST_DB_USER}" -p"${TEST_DB_PASSWORD}" --silent 2>/dev/null; do
     sleep 1
 done
 
 echo "Create encryption_key table"
-mysql --protocol=tcp -P "${TEST_DB_PORT}" -u "${TEST_DB_USER}" -p"${TEST_DB_PASSWORD}" -e "CREATE TABLE ${TEST_DB_NAME}.encryption_key (
+$CONTAINER_CMD exec $MYSQL_CONTAINER_ID mysql --protocol=tcp -P "${TEST_DB_PORT}" -u "${TEST_DB_USER}" -p"${TEST_DB_PASSWORD}" -e "CREATE TABLE ${TEST_DB_NAME}.encryption_key (
           id             VARCHAR(255) NOT NULL,
           created        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
           key_record     TEXT         NOT NULL,


### PR DESCRIPTION
### Modifications

`scripts/local-integration-test.sh`:
- Add missing export, `TEST_DB_HOSTNAME`. This variable is required by the cucumber feature implementation scripts.
- Execute `mysqladmin` commands inside the running mysql container, eliminating the client dependency.

`integration/node/features/support/encrypt.js`:
- Use the same working directory as `decrypt.js` (and the integration Asherah integration test suite). 

`integration/node/features/support/decrypt.js`:
- Use `TEST_DB_HOSTNAME` env variable for consistency (replaced hardcoded "localhost").

`integration/node` (package):
- Install `asherah` as a linked folder.