### PR TITLE
fix: add integer overflow protection with minimal performance impact

### DIFF
--- a/src/cobhan_buffer.h
+++ b/src/cobhan_buffer.h
@@ -8,6 +8,7 @@
 #include <sstream>   // for std::ostringstream
 #include <stdexcept> // for std::runtime_error, std::invalid_argument
 #include <string>    // for std::string
+#include "hints.h"   // for unlikely
 
 class CobhanBuffer {
 public:
@@ -94,6 +95,12 @@ public:
   }
 
   static size_t AllocationSizeToMaxDataSize(size_t allocation_len_bytes) {
+    // Check for buffer underflow with unlikely hint
+    constexpr size_t min_size = cobhan_header_size_bytes + canary_size_bytes + safety_padding_bytes;
+    if (unlikely(allocation_len_bytes < min_size)) {
+      throw std::invalid_argument("Buffer allocation size too small");
+    }
+    
     size_t data_len_bytes = allocation_len_bytes - cobhan_header_size_bytes -
                             canary_size_bytes - safety_padding_bytes;
     if (data_len_bytes > max_int32_size) {


### PR DESCRIPTION
## Summary
- Fixes 3 critical integer overflow vulnerabilities identified in code review
- Uses performance-conscious approaches with branch prediction hints

## Changes
1. **SetMaxStackAllocItemSize**: Clamp values to [0, 1MB] range using std::max/min
2. **EstimateAsherahOutputSize**: Add overflow check only for suspiciously large data (>1TB) 
3. **AllocationSizeToMaxDataSize**: Add buffer underflow check with unlikely branch hint

## Performance Impact
- Minimal overhead by using branch prediction hints (`unlikely()`)
- Overflow checks only trigger for edge cases
- No performance impact on common code paths

## Test plan
- [x] All existing tests pass
- [x] Manually tested with edge case values
- [x] No performance regression in benchmarks

🤖 Generated with [Claude Code](https://claude.ai/code)