### PR TITLE
Add Bun runtime support with minimal FFI initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Asherah envelope encryption and key rotation library
 
 This is a wrapper of the Asherah Go implementation using the Cobhan FFI library
 
+## Bun Runtime Support
+
+asherah-node supports [Bun](https://bun.sh) runtime with automatic compatibility. No additional setup or code changes required - the same code works in both Node.js and Bun.
+
 *NOTE:* Due to limitations around the type of libraries Go creates and the type of libraries musl libc supports, you MUST use a glibc based Linux distribution with asherah-node, such as Debian, Ubuntu, AlmaLinux, etc.  Alpine Linux with musl libc will not work.  For technical details, see below.
 
 Example code: 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "asherah",
   "version": "0.0.0",
   "description": "Asherah envelope encryption and key rotation library",
+  "main": "src/index.js",
   "exports": {
-    "node-addons": "./dist/asherah.node"
+    ".": "./src/index.js",
+    "./native": "./build/Release/asherah.node"
   },
   "repository": {
     "type": "git",
@@ -39,6 +41,7 @@
     "src/napi_utils.h",
     "src/scoped_allocate.h",
     "src/asherah.d.ts",
+    "src/index.js",
     "scripts/download-libraries.sh",
     "scripts/build.sh",
     "SHA256SUMS",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,20 @@
+/**
+ * asherah-node - Unified entry point with Bun runtime support
+ * 
+ * Automatically detects Bun runtime and initializes FFI subsystem if needed.
+ */
+
+// Initialize Bun FFI subsystem for N-API compatibility
+if (typeof Bun !== 'undefined') {
+  try {
+    require('bun:ffi');
+  } catch (error) {
+    // FFI initialization failure is fatal under Bun - N-API modules cannot load
+    throw new Error(
+      `asherah-node: Bun FFI initialization failed: ${error.message}\n` +
+      `N-API modules cannot load without FFI support. Please ensure your Bun version supports the 'bun:ffi' module.`
+    );
+  }
+}
+
+module.exports = require('../build/Release/asherah.node');


### PR DESCRIPTION
Implements Bun compatibility through ultra-minimal FFI subsystem initialization. Just require('bun:ffi') is sufficient to enable N-API module loading in Bun.

Features:
- Automatic Bun runtime detection
- Zero external dependencies
- Zero build requirements
- Identical API across Node.js and Bun runtimes
- Proper error handling with actionable messages

Implementation:
- Single line FFI init: require('bun:ffi')
- Throws descriptive error if FFI unavailable
- Seamless fallback to native module loading

This enables the same asherah-node code to work in both Node.js and Bun without any user configuration or code changes required.